### PR TITLE
Adressing multiple Issues

### DIFF
--- a/samples/arbitrary-names/app/build.gradle.kts
+++ b/samples/arbitrary-names/app/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    id("org.my.gradle.java-module")
+    id("application")
+}
+
+application {
+    applicationDefaultJvmArgs = listOf("-ea")
+    mainClass.set("org.my.app.App")
+    mainModule.set("hokus.pokus")
+}
+
+dependencies {
+    runtimeOnly(javaModuleDependencies.gav("org.slf4j.simple"))
+}

--- a/samples/arbitrary-names/app/src/main/java/module-info.java
+++ b/samples/arbitrary-names/app/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module hokus.pokus {
+    requires org.slf4j;
+    requires abra.kadabra;
+    requires static org.apache.xmlbeans;
+
+    exports org.my.app;
+}

--- a/samples/arbitrary-names/app/src/main/java/org/my/app/App.java
+++ b/samples/arbitrary-names/app/src/main/java/org/my/app/App.java
@@ -1,0 +1,27 @@
+package org.my.app;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.xmlbeans.impl.tool.XMLBean;
+import org.slf4j.spi.LoggerFactoryBinder;
+
+public class App {
+    public static void main(String[] args) {
+        doWork();
+    }
+
+    public static boolean doWork() {
+        ObjectMapper om = new ObjectMapper();
+        if (!om.canSerialize(LoggerFactoryBinder.class)) {
+            throw new RuntimeException("Boom!");
+        }
+        System.out.println(App.class.getModule().getName());
+
+        try {
+            new XMLBean();
+            throw new RuntimeException("Boom!");
+        } catch (NoClassDefFoundError e) {
+            // This is expected at runtime!
+        }
+        return true;
+    }
+}

--- a/samples/arbitrary-names/app/src/test/java/module-info.java
+++ b/samples/arbitrary-names/app/src/test/java/module-info.java
@@ -1,0 +1,4 @@
+open module org.my.app.test {
+    requires hokus.pokus;
+    requires org.junit.jupiter.api;
+}

--- a/samples/arbitrary-names/app/src/test/java/org/my/app/test/AppTest.java
+++ b/samples/arbitrary-names/app/src/test/java/org/my/app/test/AppTest.java
@@ -1,0 +1,15 @@
+package org.my.app.test;
+
+import org.junit.jupiter.api.Test;
+import org.my.app.App;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AppTest {
+
+    @Test
+    public void appDoesNotExplode() {
+        assertTrue(App.doWork());
+    }
+
+}

--- a/samples/arbitrary-names/build-logic/build.gradle.kts
+++ b/samples/arbitrary-names/build-logic/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation("org.gradlex:java-module-dependencies:1.6.5")
+}

--- a/samples/arbitrary-names/build-logic/settings.gradle.kts
+++ b/samples/arbitrary-names/build-logic/settings.gradle.kts
@@ -1,0 +1,11 @@
+val value = extra.properties["pluginLocation"] ?: rootDir.parentFile.parentFile.parent
+println(value)
+includeBuild(value)
+dependencyResolutionManagement {
+    repositories.gradlePluginPortal()
+}
+
+// This is for testing against the latest version of the plugin, remove if you copied this for a real project
+
+
+

--- a/samples/arbitrary-names/build-logic/src/main/kotlin/org.my.gradle.java-module.gradle.kts
+++ b/samples/arbitrary-names/build-logic/src/main/kotlin/org.my.gradle.java-module.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    id("java")
+    id("org.gradlex.java-module-dependencies")
+}
+
+group = "org.my"
+
+tasks.test {
+    useJUnitPlatform()
+    jvmArgs("-Dorg.slf4j.simpleLogger.defaultLogLevel=error")
+}
+
+javaModuleDependencies{
+    moduleNameCheck = false
+
+}
+
+dependencies {
+    javaModuleDependencies {
+        testRuntimeOnly(gav("org.junit.jupiter.engine"))
+        testRuntimeOnly(gav("org.junit.platform.launcher"))
+    }
+}

--- a/samples/arbitrary-names/build.out
+++ b/samples/arbitrary-names/build.out
@@ -1,0 +1,29 @@
+> Task :build-logic:jar
+> Task :lib:compileJava
+> Task :lib:processResources NO-SOURCE
+> Task :lib:classes
+> Task :lib:jar
+> Task :app:compileJava
+> Task :app:processResources NO-SOURCE
+> Task :app:classes
+> Task :app:jar
+> Task :app:startScripts
+> Task :app:distTar
+> Task :app:distZip
+> Task :app:assemble
+> Task :app:compileTestJava
+> Task :app:processTestResources NO-SOURCE
+> Task :app:testClasses
+> Task :app:test
+> Task :app:check
+> Task :app:build
+> Task :lib:assemble
+> Task :lib:compileTestJava
+> Task :lib:processTestResources NO-SOURCE
+> Task :lib:testClasses
+> Task :lib:test
+> Task :lib:check
+> Task :lib:build
+
+> Task :app:run
+hokus.pokus

--- a/samples/arbitrary-names/build.sample.conf
+++ b/samples/arbitrary-names/build.sample.conf
@@ -1,0 +1,3 @@
+executable: gradlew
+expected-output-file: build.out
+allow-disordered-output: true

--- a/samples/arbitrary-names/gradle.properties
+++ b/samples/arbitrary-names/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.configuration-cache=true

--- a/samples/arbitrary-names/gradle/libs.versions.toml
+++ b/samples/arbitrary-names/gradle/libs.versions.toml
@@ -1,0 +1,8 @@
+[versions]
+org_apache_xmlbeans = "5.0.1"
+com_fasterxml_jackson_databind = "2.12.5"
+org_slf4j = "1.7.32"
+org_slf4j_simple = "1.7.32"
+
+org_junit_jupiter_api = "5.7.2"
+org_junit_jupiter_engine = "5.7.2"

--- a/samples/arbitrary-names/lib/build.gradle.kts
+++ b/samples/arbitrary-names/lib/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("org.my.gradle.java-module")
+    id("java-library")
+}

--- a/samples/arbitrary-names/lib/src/main/java/module-info.java
+++ b/samples/arbitrary-names/lib/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module abra.kadabra {
+    requires transitive com.fasterxml.jackson.databind;
+}

--- a/samples/arbitrary-names/lib/src/test/java/module-info.java
+++ b/samples/arbitrary-names/lib/src/test/java/module-info.java
@@ -1,0 +1,4 @@
+open module org.my.lib.test {
+    requires abra.kadabra;
+    requires org.junit.jupiter.api;
+}

--- a/samples/arbitrary-names/settings.gradle.kts
+++ b/samples/arbitrary-names/settings.gradle.kts
@@ -1,0 +1,9 @@
+pluginManagement {
+    includeBuild("build-logic")
+}
+dependencyResolutionManagement {
+    repositories.mavenCentral()
+}
+
+include("app", "lib")
+

--- a/src/main/java/org/gradlex/javamodule/dependencies/JavaModuleDependenciesExtension.java
+++ b/src/main/java/org/gradlex/javamodule/dependencies/JavaModuleDependenciesExtension.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Optional.empty;
 import static org.gradlex.javamodule.dependencies.internal.utils.ModuleInfo.Directive.REQUIRES_RUNTIME;

--- a/src/main/java/org/gradlex/javamodule/dependencies/internal/utils/ModuleInfo.java
+++ b/src/main/java/org/gradlex/javamodule/dependencies/internal/utils/ModuleInfo.java
@@ -81,6 +81,10 @@ public class ModuleInfo implements Serializable {
         return Collections.emptyList();
     }
 
+    public String getModuleName() {
+        return moduleName;
+    }
+
     @Nullable
     public String moduleNamePrefix(String projectName, String sourceSetName, boolean fail) {
         if (moduleName.equals(projectName)) {

--- a/src/main/java/org/gradlex/javamodule/dependencies/internal/utils/ModuleInfoCache.java
+++ b/src/main/java/org/gradlex/javamodule/dependencies/internal/utils/ModuleInfoCache.java
@@ -58,7 +58,7 @@ public abstract class ModuleInfoCache {
         return ModuleInfo.EMPTY;
     }
 
-    public boolean containsModule(String moduleName) {
-        return moduleInfo.values().stream().anyMatch(x -> x.getModuleName().equals(moduleName));
+    public boolean containsModule(SourceSet sourceSet, String moduleName) {
+        return get(sourceSet).getModuleName().equals(moduleName);
     }
 }

--- a/src/main/java/org/gradlex/javamodule/dependencies/internal/utils/ModuleInfoCache.java
+++ b/src/main/java/org/gradlex/javamodule/dependencies/internal/utils/ModuleInfoCache.java
@@ -57,4 +57,8 @@ public abstract class ModuleInfoCache {
         }
         return ModuleInfo.EMPTY;
     }
+
+    public boolean containsModule(String moduleName) {
+        return moduleInfo.values().stream().anyMatch(x -> x.getModuleName().equals(moduleName));
+    }
 }

--- a/src/main/java/org/gradlex/javamodule/dependencies/tasks/ModuleDependencyReport.java
+++ b/src/main/java/org/gradlex/javamodule/dependencies/tasks/ModuleDependencyReport.java
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.diagnostics.DependencyReportTask;
 import org.gradlex.javamodule.dependencies.internal.diagnostics.AsciiModuleDependencyReportRenderer;
 
 import javax.inject.Inject;
+import java.util.Collections;
 import java.util.Set;
 
 @NonNullApi
@@ -64,7 +65,7 @@ public abstract class ModuleDependencyReport extends DependencyReportTask {
 
     private void configurationsChanged() {
         getModulePath().setFrom();
-        getModuleArtifacts().unset();
+        getModuleArtifacts().set(Collections.emptyMap());
         for (Configuration conf : getConfigurations()) {
             getModulePath().from(conf);
             getModuleArtifacts().put(conf.getName(), getProviders().provider(() -> conf.getIncoming().getArtifacts()));


### PR DESCRIPTION
Hello,

Ok So this change adresses 3 thing.

1. ModuleDependencyReport uses  ` getModuleArtifacts().unset(); ` but that doesn't seem exist before gradle 8.6 (or 8.7?), which can create some unexpected problems..
2. As mentioned in #108 : Lets not full explode with no chance of continuing the build when multiple projects share the same name. Some functionality might be reduced, warnings are printed..
3. Lets just skip the path heuristic entirely if this  plugin is applied to the corresponding project and we have already parsed the module file and we absolutely know the modulename. This allows the plugin to support arbitrary modulenames. Modulenamecheck must be disabled for that to work, or else it will complain..

The last point could also be hidden behind config/feature switch, but gradle test shows all good.
Copy and pasted some other sample project and adjusted the modulenames, looks good to me