### PR TITLE
Add the java.annotation module

### DIFF
--- a/src/main/resources/org/gradlex/javamodule/dependencies/modules.properties
+++ b/src/main/resources/org/gradlex/javamodule/dependencies/modules.properties
@@ -29,6 +29,7 @@ io.netty.transport=io.netty:netty-transport
 io.swagger.v3.oas.annotations=io.swagger.core.v3:swagger-annotations
 io.swagger.v3.oas.models=io.swagger.core.v3:swagger-models
 jakarta.messaging=jakarta.jms:jakarta.jms-api
+java.annotation=javax.annotation:javax.annotation-api
 java.inject=jakarta.inject:jakarta.inject-api
 java.validation=jakarta.validation:jakarta.validation-api
 javafx.base=org.openjfx:javafx-base


### PR DESCRIPTION
Adds the java.annotation module to the list of pre-known modules. Please note that the module name is `java.annotation`, but the actual package is `javax.annotation`. This was very surprising, but is the result of the artifact name vs. the package name.