### PR TITLE
Property to disable tasks not needed for plugin's main functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Java Module Dependencies Gradle Plugin - Changelog
 
 ## Version 1.8
+* [#141](https://github.com/gradlex-org/java-module-dependencies/pull/141) Introduce `org.gradlex.java-module-dependencies.register-help-tasks` property
 * [#127](https://github.com/gradlex-org/java-module-dependencies/issues/127) Less configuration cache misses when modifying `module-info.java` (Thanks [TheGoesen](https://github.com/TheGoesen))
 * [#128](https://github.com/gradlex-org/java-module-dependencies/issues/128) Less configuration cache misses when using Settings plugin (Thanks [TheGoesen](https://github.com/TheGoesen))
 * [#135](https://github.com/gradlex-org/java-module-dependencies/issues/135) Improve performance of ApplyPluginsAction

--- a/src/main/java/org/gradlex/javamodule/dependencies/internal/bridges/DependencyAnalysisBridge.java
+++ b/src/main/java/org/gradlex/javamodule/dependencies/internal/bridges/DependencyAnalysisBridge.java
@@ -26,11 +26,12 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesOrderingCheck;
 import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesScopeCheck;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 public class DependencyAnalysisBridge {
 
-    public static void registerDependencyAnalysisPostProcessingTask(Project project, TaskProvider<Task> checkAllModuleInfo) {
+    public static void registerDependencyAnalysisPostProcessingTask(Project project, @Nullable TaskProvider<Task> checkAllModuleInfo) {
         TaskContainer tasks = project.getTasks();
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
 
@@ -54,7 +55,9 @@ public class DependencyAnalysisBridge {
         project.getExtensions().getByType(AbstractExtension.class)
                 .registerPostProcessingTask(checkModuleDirectivesScope);
 
-        checkAllModuleInfo.configure(t -> t.dependsOn(checkModuleDirectivesScope));
+        if (checkAllModuleInfo != null) {
+            checkAllModuleInfo.configure(t -> t.dependsOn(checkModuleDirectivesScope));
+        }
         tasks.withType(ModuleDirectivesOrderingCheck.class).configureEach(t -> t.mustRunAfter(checkModuleDirectivesScope));
     }
 }

--- a/src/test/groovy/org/gradlex/javamodule/dependencies/test/BasicFunctionalityTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/dependencies/test/BasicFunctionalityTest.groovy
@@ -6,7 +6,7 @@ import spock.lang.Specification
 class BasicFunctionalityTest extends Specification {
 
     @Delegate
-    GradleBuild build = new GradleBuild()
+    GradleBuild build = new GradleBuild(true)
 
     def "can configure all tasks in a build without error"() {
         given:

--- a/src/test/groovy/org/gradlex/javamodule/dependencies/test/OrderingCheckTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/dependencies/test/OrderingCheckTest.groovy
@@ -6,7 +6,7 @@ import spock.lang.Specification
 class OrderingCheckTest extends Specification {
 
     @Delegate
-    GradleBuild build = new GradleBuild()
+    GradleBuild build = new GradleBuild(true)
 
     def "order is expected to be alphabetic for each scope individually"() {
         when:

--- a/src/test/groovy/org/gradlex/javamodule/dependencies/test/fixture/GradleBuild.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/dependencies/test/fixture/GradleBuild.groovy
@@ -8,6 +8,7 @@ import java.nio.file.Files
 
 class GradleBuild {
 
+    final boolean withHelpTasks
     final File projectDir
     final File settingsFile
     final File appBuildFile
@@ -17,7 +18,8 @@ class GradleBuild {
 
     final String gradleVersionUnderTest = System.getProperty("gradleVersionUnderTest")
 
-    GradleBuild(File projectDir = Files.createTempDirectory("gradle-build").toFile()) {
+    GradleBuild(boolean withHelpTasks = false, File projectDir = Files.createTempDirectory("gradle-build").toFile()) {
+        this.withHelpTasks = withHelpTasks
         this.projectDir = projectDir
         this.settingsFile = file("settings.gradle.kts")
         this.appBuildFile = file("app/build.gradle.kts")
@@ -98,7 +100,8 @@ class GradleBuild {
                 .forwardOutput()
                 .withPluginClasspath()
                 .withProjectDir(projectDir)
-                .withArguments(Arrays.asList(args) + latestFeaturesArgs + '-s' + '--warning-mode=all')
+                .withArguments(Arrays.asList(args) + latestFeaturesArgs + '-s' + '--warning-mode=all'
+                        + "-Porg.gradlex.java-module-dependencies.register-help-tasks=$withHelpTasks".toString())
                 .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments().toString().contains("-agentlib:jdwp")).with {
             gradleVersionUnderTest ? it.withGradleVersion(gradleVersionUnderTest) : it
         }


### PR DESCRIPTION
This property – `org.gradlex.java-module-dependencies.register-help-tasks` – is a "quick" solution to make this feature available and gather feedback from users. See: #130

Eventually, tasks should be:
- moved to a separate plugin
- or removed completely if not considered useful anymore

This would be a breaking change and thus should be done only in the next major release.