### PR TITLE
Add 'exportsTo' and 'opensTo' statements to Module Info DSL

### DIFF
--- a/src/main/java/org/gradlex/javamodule/dependencies/dsl/AllDirectives.java
+++ b/src/main/java/org/gradlex/javamodule/dependencies/dsl/AllDirectives.java
@@ -35,4 +35,12 @@ abstract public class AllDirectives extends GradleOnlyDirectives {
         compileClasspathModules.add(moduleName);
         add(sourceSet.getCompileOnlyConfigurationName(), moduleName);
     }
+
+    public void exportsTo(String moduleName) {
+        exportsToModules.add(moduleName);
+    }
+
+    public void opensTo(String moduleName) {
+        opensToModules.add(moduleName);
+    }
 }

--- a/src/main/java/org/gradlex/javamodule/dependencies/dsl/GradleOnlyDirectives.java
+++ b/src/main/java/org/gradlex/javamodule/dependencies/dsl/GradleOnlyDirectives.java
@@ -32,6 +32,8 @@ public abstract class GradleOnlyDirectives {
 
     protected final List<String> compileClasspathModules = new ArrayList<>();
     protected final List<String> runtimeClasspathModules = new ArrayList<>();
+    protected final List<String> exportsToModules = new ArrayList<>();
+    protected final List<String> opensToModules = new ArrayList<>();
 
     @Inject
     protected abstract DependencyHandler getDependencies();

--- a/src/main/java/org/gradlex/javamodule/dependencies/internal/dsl/AllDirectivesInternal.java
+++ b/src/main/java/org/gradlex/javamodule/dependencies/internal/dsl/AllDirectivesInternal.java
@@ -22,6 +22,10 @@ import org.gradlex.javamodule.dependencies.dsl.AllDirectives;
 
 import java.util.List;
 
+/**
+ * Note: These methods are used by the 'java-module-testing' plugin to access information
+ * defined in the Module Info DSL.
+ */
 abstract public class AllDirectivesInternal extends AllDirectives {
 
     public AllDirectivesInternal(SourceSet sourceSet, SourceSet mainSourceSet, JavaModuleDependenciesExtension javaModuleDependencies) {
@@ -34,5 +38,13 @@ abstract public class AllDirectivesInternal extends AllDirectives {
 
     public List<String> getRuntimeClasspathModules() {
         return runtimeClasspathModules;
+    }
+
+    public List<String> getExportsToModules() {
+        return exportsToModules;
+    }
+
+    public List<String> getOpensToModules() {
+        return opensToModules;
     }
 }


### PR DESCRIPTION
These can then be picked up by the 'java-module-testing' plugin.